### PR TITLE
New bot cmds

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -119,6 +119,42 @@ controller.hears("define (.*)", "direct_message,direct_mention,mention", functio
     request(options, callback);
 });
 
+
+controller.hears("scoreboard (.*)","direct_message,direct_mention,mention",function(bot,message) {
+
+	 let input = message.match[1];
+	 let parms = input.split(" ");
+
+	 let auth = "Basic " + new Buffer(config.mysportsfeeds).toString("base64");
+
+	 let api = "https://api.mysportsfeeds.com/v1.1/pull/" + parms[0] + "/2016-regular/scoreboard.json?fordate="+parms[1];
+
+	 var options={
+		 url: api,
+		 headers: {
+ 		 	'Authorization': auth
+		}
+	 }
+   
+	 request.get(options, function(error,response,body){
+	    if (!error && response.statusCode === 200) {
+	   		// Try to parse the json. If it errors it gets caught.
+	    	let scoreboardjson = JSON.parse(body);
+
+				let awayTeam = scoreboardjson['scoreboard']['gameScore'][0]['game']['awayTeam']['Abbreviation']
+				let homeTeam = scoreboardjson['scoreboard']['gameScore'][0]['game']['homeTeam']['Abbreviation']
+				let awayScore = scoreboardjson['scoreboard']['gameScore'][0]['awayScore']
+				let homeScore = scoreboardjson['scoreboard']['gameScore'][0]['homeScore']
+
+	    	bot.reply(message, awayTeam + " " + awayScore + " |VS| " + homeTeam + " " + homeScore);
+	    }
+	    else  {
+	         console.error(error);
+	         console.log(response);
+	        };
+	 });
+});
+
 controller.hears("date", "direct_message,direct_mention,mention", function(bot, message) {
     let datetime = new Date();
     bot.reply(message, "Today is: " + datetime);

--- a/bot.js
+++ b/bot.js
@@ -120,7 +120,7 @@ controller.hears("define (.*)", "direct_message,direct_mention,mention", functio
 });
 
 
-controller.hears("scoreboard (.*)","direct_message,direct_mention,mention",function(bot,message) {
+controller.hears("scores (.*)","direct_message,direct_mention,mention",function(bot,message) {
 
 	 let input = message.match[1];
 	 let parms = input.split(" ");
@@ -135,18 +135,26 @@ controller.hears("scoreboard (.*)","direct_message,direct_mention,mention",funct
  		 	'Authorization': auth
 		}
 	 }
-   
+
 	 request.get(options, function(error,response,body){
 	    if (!error && response.statusCode === 200) {
 	   		// Try to parse the json. If it errors it gets caught.
 	    	let scoreboardjson = JSON.parse(body);
 
-				let awayTeam = scoreboardjson['scoreboard']['gameScore'][0]['game']['awayTeam']['Abbreviation']
-				let homeTeam = scoreboardjson['scoreboard']['gameScore'][0]['game']['homeTeam']['Abbreviation']
-				let awayScore = scoreboardjson['scoreboard']['gameScore'][0]['awayScore']
-				let homeScore = scoreboardjson['scoreboard']['gameScore'][0]['homeScore']
+        if (scoreboardjson['scoreboard']['gameScore'] === undefined){
+          bot.reply(message, "Sorry!  I couldn't find any scores for that day");
+        }
+        else{
+          bot.reply(message, "Here are the scores for that day:");
 
-	    	bot.reply(message, awayTeam + " " + awayScore + " |VS| " + homeTeam + " " + homeScore);
+          for (var i = 0; i < scoreboardjson['scoreboard']['gameScore'].length; i++) {
+				      let awayTeam = scoreboardjson['scoreboard']['gameScore'][i]['game']['awayTeam']['Abbreviation']
+				      let homeTeam = scoreboardjson['scoreboard']['gameScore'][i]['game']['homeTeam']['Abbreviation']
+				      let awayScore = scoreboardjson['scoreboard']['gameScore'][i]['awayScore']
+				      let homeScore = scoreboardjson['scoreboard']['gameScore'][i]['homeScore']
+              bot.reply(message, ">" + awayTeam + " " + awayScore + " |VS| " + homeTeam + " " + homeScore);
+          }
+        }
 	    }
 	    else  {
 	         console.error(error);

--- a/config.js
+++ b/config.js
@@ -4,10 +4,11 @@ const config = {
     weathertoken: "", //From OpenWeatherMap
     app_id: "", // App ID From Oxford Dictionaries
     app_key: "", // App Key From Oxford Dictionaries
-    language: "en", // Language for Oxford Dictionaries 
+    language: "en", // Language for Oxford Dictionaries
     cse: "", // Google Custom Search Engine Key.
     cseapi: "", // Google Search API Key.
-    gifapi: "" // Tenor API Key  
+    gifapi: "", // Tenor API Key
+    mysportsfeeds:"" //mysportsfeeds username and password for basic auth
 };
 
 module.exports = config;


### PR DESCRIPTION
Added a new command to retrieve sports scores   #1 
Command utilizes [MySportsFeed API](https://www.mysportsfeeds.com/data-feeds/api-docs/#).
The api requires basic auth, there is a new config property for the username:password, which is encrypted and added to the auth header for the request call.

##### Example:
`scores nfl 20161023`
```
Here are the scores for that day:
IND 34 |VS| TEN 26
NYG 17 |VS| LA 10
MIN 10 |VS| PHI 21
CLE 17 |VS| CIN 31
WAS 17 |VS| DET 20
OAK 33 |VS| JAX 16
NO 21 |VS| KC 27
BUF 25 |VS| MIA 28
TB 34 |VS| SF 17
SD 33 |VS| ATL 30
NE 27 |VS| PIT 16
BAL 16 |VS| NYJ 24
SEA 6 |VS| ARI 6
```
_Note:  The api is free for past seasons.  Currently will pull 2016 Regular season scores.  NFL, NHL, NBA and MLB scores are available_